### PR TITLE
Drop Query Parameters from Url Attribute

### DIFF
--- a/plugin/ochttp/trace.go
+++ b/plugin/ochttp/trace.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptrace"
+	"strings"
 
 	"go.opencensus.io/plugin/ochttp/propagation/b3"
 	"go.opencensus.io/trace"
@@ -154,9 +155,12 @@ func requestAttrs(r *http.Request) []trace.Attribute {
 	userAgent := r.UserAgent()
 
 	attrs := make([]trace.Attribute, 0, 5)
+	// RCCA-9454: Remove query parameters from URL.
+	// Cut the URL string at the first occurrence of '?' and discard the query parameters.
+	urlAttr, _, _ := strings.Cut(r.URL.String(), "?")
 	attrs = append(attrs,
 		trace.StringAttribute(PathAttribute, r.URL.Path),
-		trace.StringAttribute(URLAttribute, r.URL.String()),
+		trace.StringAttribute(URLAttribute, urlAttr),
 		trace.StringAttribute(HostAttribute, r.Host),
 		trace.StringAttribute(MethodAttribute, r.Method),
 	)

--- a/plugin/ochttp/trace_test.go
+++ b/plugin/ochttp/trace_test.go
@@ -476,6 +476,21 @@ func TestRequestAttributes(t *testing.T) {
 				trace.StringAttribute("http.user_agent", "ua"),
 			},
 		},
+		{
+			name: "GET example.com/hello?secret=todrop",
+			makeReq: func() *http.Request {
+				req, _ := http.NewRequest("GET", "http://example.com:779/hello?secret=todrop", nil)
+				req.Header.Add("User-Agent", "ua")
+				return req
+			},
+			wantAttrs: []trace.Attribute{
+				trace.StringAttribute("http.path", "/hello"),
+				trace.StringAttribute("http.url", "http://example.com:779/hello"),
+				trace.StringAttribute("http.host", "example.com:779"),
+				trace.StringAttribute("http.method", "GET"),
+				trace.StringAttribute("http.user_agent", "ua"),
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
RCCA-9454
Query parameters are logged in URL attributes, which may contain sensitive information.

Stripping off the query parameter from URL attribute.

Testing:
Added a test case.